### PR TITLE
The plugin doesn't work 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
 function rewireBundleAnalyzer(config) {
-  config.plugins.push(rewireBundleAnalyzer())
+  config.plugins.push(new BundleAnalyzerPlugin())
 
   return config
 }


### PR DESCRIPTION
The plugin doesn't seem to work because the function to add it is invoking itself rather than initialising the BundleAnalyzerPlugin plugin